### PR TITLE
Doc generation enhancements on the ruby side

### DIFF
--- a/lib/praxis/collection.rb
+++ b/lib/praxis/collection.rb
@@ -8,6 +8,7 @@ module Praxis
       end
 
       klass = super
+      klass.anonymous_type
 
       if type < Praxis::Types::MediaTypeCommon
         klass.member_type type

--- a/lib/praxis/docs/generator.rb
+++ b/lib/praxis/docs/generator.rb
@@ -125,7 +125,6 @@ module Praxis
         collect_reachable_types( found_media_types , collected_types );
 
         dumped_schemas = dump_schemas( collected_types )
-
         full_data = {
           info: version_info[:info],
           resources: dumped_resources,
@@ -169,9 +168,13 @@ module Praxis
       def dump_schemas(types)
         reportable_types = types - EXCLUDED_TYPES_FROM_OUTPUT
         reportable_types.each_with_object({}) do |type, array|
+          next if ( type.respond_to?(:anonymous?) && type.anonymous? )
+
           context = [type.id]
           example_data = type.example(context)
           type_output = type.describe(false, example: example_data)
+
+          type_output[:display_name] = type.display_name if type.respond_to?(:display_name)
           unless type_output[:display_name]
             # For non MediaTypes or pure types or anonymous types fallback to their name, and worst case to their id
             type_output[:display_name] = type_output[:name] || type_output[:id]

--- a/lib/praxis/extensions/field_selection/field_selector.rb
+++ b/lib/praxis/extensions/field_selection/field_selector.rb
@@ -10,6 +10,14 @@ module Praxis
             self
           end
 
+          def self.display_name
+            'FieldSelector'
+          end
+
+          def family
+            'string'
+          end
+
           def self.for(media_type)
             unless media_type < Praxis::MediaType
               raise ArgumentError, "Invalid type: #{media_type.name} for FieldSelector. " +

--- a/lib/praxis/links.rb
+++ b/lib/praxis/links.rb
@@ -32,6 +32,7 @@ module Praxis
       klass = Class.new(self) do
         @reference = reference
         @links = Hash.new
+        anonymous_type
       end
 
       reference.const_set :Links, klass


### PR DESCRIPTION
- Added examples for action headers and params (including required ones only)
- Changed generator to skip including types that are marked anonymous as available schemas.
- Mark `Praxis::Links` and `Praxis::Collection` classes anonymous by default so the doc browser can embed them in the tables and does not list them as named schemas.
- Changed `FieldSelector` to have a proper `display_name` and changed its type to `string`

Needs UI code to take advantage of the "anonymous" option of a type so they:
- Are always embeded in the table (rather than linked to the schema). Usually would mean embedding the sub-structure OR describing them as a collection of (and embed the substructure of the member_type)

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
